### PR TITLE
Do not emit agentRemove event 

### DIFF
--- a/lib/persistent-tunnel.coffee
+++ b/lib/persistent-tunnel.coffee
@@ -27,7 +27,6 @@ module.exports.createConnection = (options, cb) ->
 			if proxyOptions.timeout?
 				socket.setTimeout proxyOptions.timeout, ->
 					socket.destroy()
-					socket.emit('agentRemove')
 			cb(null, socket)
 		else
 			onError(null, res)


### PR DESCRIPTION
Socket will get removed from the agent anyway after destroy() - see [this](https://github.com/resin-io/persistent-tunnel#timeout-setting) README section.
