### PR TITLE
Do not call 'removeAllListeners()' on created socket.

### DIFF
--- a/build/persistent-tunnel.js
+++ b/build/persistent-tunnel.js
@@ -43,7 +43,6 @@
       return cb(error);
     };
     onConnect = function(res, socket, head) {
-      socket.removeAllListeners();
       if (res.statusCode === 200) {
         if (proxyOptions.timeout != null) {
           socket.setTimeout(proxyOptions.timeout, function() {

--- a/lib/persistent-tunnel.coffee
+++ b/lib/persistent-tunnel.coffee
@@ -21,8 +21,6 @@ module.exports.createConnection = (options, cb) ->
 		cb(error)
 
 	onConnect = (res, socket, head) ->
-		socket.removeAllListeners()
-
 		if res.statusCode is 200
 			if proxyOptions.timeout?
 				socket.setTimeout proxyOptions.timeout, ->


### PR DESCRIPTION
The idea was to pass the socket in a 'clear' state to the requesting
Agent, but it has the side effect that if the tunnel's HTTP response
is not 200, then the socket will never be properly closed when the tunnel
server eventually closes the connection from its side.

Connects to #6 
